### PR TITLE
fix: resolve merge conflicts in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,11 +338,7 @@ dependencies = [
 
 [[package]]
 name = "argon-rbx"
-<<<<<<< Updated upstream
-version = "0.0.7"
-=======
-version = "0.0.6"
->>>>>>> Stashed changes
+version = "0.0.8"
 dependencies = [
  "actix-msgpack",
  "actix-web",


### PR DESCRIPTION
This PR fixes the broken Cargo.lock file that was causing GitHub Actions builds to fail with a TOML parsing error.